### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ agate start 3000 '' dev
 node --harmony agate 
 ```
 
-##直接启动命令
+## 直接启动命令
 ```javascript
 agate agate scaffold /test2 test2  index post#create
 ```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
